### PR TITLE
Build for linux/amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ validate-version:
 
 build: tag
 	@echo "---> [Executing docker build]"
-	@docker build . -t $(IMAGE)
+	@docker buildx build --platform linux/amd64 --push . -t $(IMAGE)
 	@docker push $(IMAGE)
 	@echo $(IMAGE)
 


### PR DESCRIPTION
As we're building the images locally the image target architecture will match the build machine, in my case arm64. 

Here we invoke Dockers 'buildx' functionality to build for the correct architecture.