### PR TITLE
[INFRA-3533] Change target column in link table to `text` type

### DIFF
--- a/server/migrations/20230723093000_links_target_length.ts
+++ b/server/migrations/20230723093000_links_target_length.ts
@@ -3,7 +3,7 @@ import { Knex } from "knex";
 export async function up(knex: Knex): Promise<any> {
 
   await knex.schema.alterTable("links", table => {
-    table.string("target").notNullable().alter();
+    table.text("target").notNullable().alter();
   });
 }
 

--- a/server/models/link.ts
+++ b/server/models/link.ts
@@ -24,7 +24,7 @@ export async function createLinkTable(knex: Knex) {
         .inTable("domains");
       table.string("password");
       table.dateTime("expire_in");
-      table.string("target").notNullable();
+      table.text("target").notNullable();
       table
         .integer("user_id")
         .references("id")


### PR DESCRIPTION
Test schedule:
- Revert back to current production configuration, bring up the stack:
```
git checkout main
git reset --hard HEAD~1
docker-compose up -d --build
```
- Shorten a [URL](https://prometheus.bugsnag.com/graph?g0.expr=sum(max_over_time(custom_rabbitmq_queue%7Bqueue_name%3D~%22reports-android-prioritized%7Creports-cocos2dx-prioritized%7Creports-default-prioritized%7Creports-electron-prioritized%22%7D%5B1m%5D))%20%3E%20500000&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) longer than 255 characters, copy the resultant link
- Come back to HEAD on this branch, rebuild containers, allow migration to happen:
```
git checkout jm/alter-link-target-col
docker-compose up -d --build
```
- Test the shortened URL from early (specifically: The Prometheus query should not be truncated)
- Shorten a [URL](https://prometheus.bugsnag.com/graph?g0.expr=sum(max_over_time(custom_rabbitmq_queue%7Bqueue_name%3D~%22reports-android-prioritized%7Creports-cocos2dx-prioritized%7Creports-default-prioritized%7Creports-electron-prioritized%7Creports-expo-prioritized%7Creports-flutter-prioritized%7Creports-js-prioritized%7Creports-macho-prioritized%7Creports-minidump-prioritized%7Creports-react-native-prioritized%7Creports-switch-prioritized%7Creports-unity-prioritized%7Creports-unreal-prioritized%7Csdaqaqehqwouehqohjeoqheoqwhoeq%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%7Cqliwugqiwebiqwbeiuqweiuqbiuwehqiuehiuqwheiuqhwdiubqidbqiwdbqiuwbdiuqbwdiuqbwdiuqhwiuehqiuweghiqugdibqwdibqidbqiuwdbiquwhdiuqbwdiuqbwidubqwiudbqiuwiuqhwruohqwiuodhqouwdbqiurbiuqwgriuyqgsixbqwiourhqiuwgheiuqbsiuqbwieugqiwuebw%22%7D%5B1m%5D))%20%3E%20500000&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) longer than 5000 characters and open it

The test schedule was completed successfully.