### PR TITLE
Upgrade tar to 7.5.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
   },
   "packageManager": "yarn@4.0.2",
   "resolutions": {
-    "tar": "7.5.16"
+    "tar": "7.5.19"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8261,16 +8261,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.16":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+"tar@npm:7.5.19":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
##Summary

- Updated 'tar' resolution from 7.5.16 to 7.5.19 in "package.json".
- Regenerated "yarn.lock".
- Verified the resolution version is "tar@7.5.19".